### PR TITLE
Fix curl for creating new service contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Create a new Service Contract:
 curl -X POST localhost:9190/contracts \
 -H 'Content-type: application/json' \
 -d '{
-  "recipientArkAddress": "ARNJJruY6RcuYCXcwWsu4bx9kyZtntqeAx"
+  "arguments": {
+    "recipientArkAddress": "ARNJJruY6RcuYCXcwWsu4bx9kyZtntqeAx"
+  }
 }' 
 ```
 


### PR DESCRIPTION
The example doesn't work because when calling `createContractRequest.getArguments()` return `null` which means that `createContractRequest.getArguments().getRecipientEthAddress()` will fail.